### PR TITLE
feat: opt node selectors for registry and sync

### DIFF
--- a/justfile
+++ b/justfile
@@ -8,7 +8,7 @@ test-lint:
 
 test-unit:
 	helm plugin ls | grep unittest || helm plugin install https://github.com/quintush/helm-unittest
-	helm unittest -f 'test/unit/*.yaml' -3 .
+	helm unittest -f 'test/unit/*.yaml' .
 
 test: test-lint test-unit
 

--- a/templates/deployment-registry.yaml
+++ b/templates/deployment-registry.yaml
@@ -20,6 +20,10 @@ spec:
       containers:
         - name: registry
           image: {{ include "apicurio-registry.image" .Values.registry }}
+          {{- with .Values.registry.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 8080
               name: http

--- a/templates/deployment-sync.yaml
+++ b/templates/deployment-sync.yaml
@@ -20,6 +20,10 @@ spec:
       containers:
         - name: sync
           image: {{ .Values.sync.image.registry }}/{{ .Values.sync.image.repository }}:{{ .Values.sync.image.tag }}
+          {{- with .Values.sync.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           imagePullPolicy: "Always"
           env:
             - name: APICURIO_REGISTRY_URL

--- a/test/linter/test.sh
+++ b/test/linter/test.sh
@@ -70,6 +70,16 @@ if [ $? -eq 0 ]; then
   exit 1
 fi
 
+helm lint . --strict --set registry.nodeSelector.foo=bar
+if [ $? -ne 0 ]; then
+  exit 1
+fi
+
+helm lint . --strict --set sync.nodeSelector.foo=bar
+if [ $? -ne 0 ]; then
+  exit 1
+fi
+
 echo "=================================================================================="
 echo "                                LINT PASSED"
 echo "=================================================================================="

--- a/test/unit/test_nodeselector.yaml
+++ b/test/unit/test_nodeselector.yaml
@@ -1,0 +1,35 @@
+suite: test registry node selector
+templates:
+  - deployment-registry.yaml
+tests:
+  - it: no selector
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].nodeSelector
+  - it: with node selectors
+    set:
+      registry:
+        nodeSelector:
+          foo: bar
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].nodeSelector.foo
+          value: bar
+---
+suite: test sync node selector
+templates:
+  - deployment-sync.yaml
+tests:
+  - it: no selector
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].nodeSelector
+  - it: with node selectors
+    set:
+      registry:
+        nodeSelector:
+          foo: bar
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].nodeSelector.foo
+          value: bar

--- a/values.schema.json
+++ b/values.schema.json
@@ -79,6 +79,7 @@
       "properties": {
         "enabled": {"$ref": "#/definitions/isEnabled"},
         "image": {"$ref": "#/definitions/dockerImage"},
+        "nodeSelector": {"type": "object", "title": "node selector for registry"},
         "extraEnv": {
           "type": "array", "default": [],
           "items": {"$ref": "#/definitions/keyValue"}
@@ -95,6 +96,7 @@
       "properties": {
         "enabled": {"$ref": "#/definitions/isEnabled"},
         "image": {"$ref": "#/definitions/dockerImage"},
+        "nodeSelector": {"type": "object", "title": "node selector for registry content sync"},
         "resources": {"$ref": "#/definitions/podResources"},
         "registryUrl": {"type": ["null", "string"], "default": null}
       }

--- a/values.yaml
+++ b/values.yaml
@@ -15,6 +15,8 @@ registry:
     registry: "quay.io"
     repository: "apicurio/apicurio-registry"
     tag: "2.3.1.Final"
+  # optional node selector
+  nodeSelector: {}
   # list of name, value pairs of extra environment vars
   extraEnv: []
     # - name: SOME_ENV
@@ -41,6 +43,8 @@ sync:
     registry: "quay.io"
     repository: "apicurio/apicurio-registry-kube-sync"
     tag: "d0e2505"
+  # optional node selector
+  nodeSelector: {}
   # registryUrl:
   resources: {}
     # limits:


### PR DESCRIPTION
Optional node selectors for k8s deployment.
This is useful for me as I need to specify which node groups my Apicurio Registry can be assigned to. Could be useful to others as well.