### PR TITLE
fix: env vars from secrets and configmap + values.schema update

### DIFF
--- a/test/unit/deployment_registry.yaml
+++ b/test/unit/deployment_registry.yaml
@@ -109,3 +109,35 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].env[0].value
           value: VALUE
+  - it: plain extra env
+    set:
+      registry:
+        extraEnv:
+          - name: ENV_VAR
+            value: VALUE
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[3].name
+          value: ENV_VAR
+      - equal:
+          path: spec.template.spec.containers[0].env[3].value
+          value: VALUE
+  - it: extra env from secret
+    set:
+      registry:
+        extraEnv:
+         - name: FOO
+           valueFrom:
+             secretKeyRef:
+               name: bar
+               key: baz
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[3].name
+          value: FOO
+      - equal:
+          path: spec.template.spec.containers[0].env[3].valueFrom.secretKeyRef.name
+          value: bar
+      - equal:
+          path: spec.template.spec.containers[0].env[3].valueFrom.secretKeyRef.key
+          value: baz

--- a/values.schema.json
+++ b/values.schema.json
@@ -46,14 +46,6 @@
         }
       }
     },
-    "keyValue": {
-      "type": "object", "additionalProperties": false,
-      "required": ["name", "value"],
-      "properties": {
-        "name": { "type": "string"},
-        "value": {"type": "string"}
-      }
-    },
     "initContainers": {
       "type": "array", "default": []
     },
@@ -89,14 +81,24 @@
         "enabled": {"$ref": "#/definitions/isEnabled"},
         "image": {"$ref": "#/definitions/dockerImage"},
         "nodeSelector": {"type": "object", "title": "node selector for registry"},
-        "initContainers": {"$ref": "#/definitions/initContainers"},
+        "initContainers": {"$ref": "#/definitions/initContainers", "title": "init containers for registry"},
         "extraEnv": {
-          "type": "array", "default": [],
-          "items": {"$ref": "#/definitions/keyValue"}
+          "type": "array",
+          "title": "extra environment variables for registry",
+          "default": [],
+          "items": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            }
+          }
         },
         "resources": {"$ref": "#/definitions/podResources"},
-        "extraVolumeMounts": {"$ref": "#/definitions/volumeMounts"},
-        "extraVolumes": {"$ref": "#/definitions/volumes"},
+        "extraVolumeMounts": {"$ref": "#/definitions/volumeMounts", "title": "extra volume mounts for registry"},
+        "extraVolumes": {"$ref": "#/definitions/volumes", "title": "extra volumes for registry"},
         "kafka": {"$ref": "#/definitions/persistence/kafka"},
         "sql": {"$ref": "#/definitions/persistence/sql"},
         "ingress": {"$ref": "#/definitions/ingress"}
@@ -109,10 +111,10 @@
         "enabled": {"$ref": "#/definitions/isEnabled"},
         "image": {"$ref": "#/definitions/dockerImage"},
         "nodeSelector": {"type": "object", "title": "node selector for registry content sync"},
-        "initContainers": {"$ref": "#/definitions/initContainers"},
+        "initContainers": {"$ref": "#/definitions/initContainers", "title": "init containers for registry content sync"},
         "resources": {"$ref": "#/definitions/podResources"},
-        "extraVolumeMounts": {"$ref": "#/definitions/volumeMounts"},
-        "extraVolumes": {"$ref": "#/definitions/volumes"},
+        "extraVolumeMounts": {"$ref": "#/definitions/volumeMounts", "title": "extra volume mounts for registry content sync"},
+        "extraVolumes": {"$ref": "#/definitions/volumes", "title": "extra volumes for registry content sync"},
         "registryUrl": {"type": ["null", "string"], "default": null}
       }
     }


### PR DESCRIPTION
This is needed because environment variables can be defined from configMaps and/or Secrets.

Example:
```
extraEnv:
- name: KAFKA_SSL_TRUSTSTORE_PASSWORD 
  valueFrom: 
    secretKeyRef: 
      name: apicurio 
      key: user.password
```

This currently fails with:
```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
apicurio-registry:
- registry.extraEnv.0: value is required
- registry.extraEnv.0: Additional property valueFrom is not allowed
``` 
