### PR TITLE
feat: add ingressClassName

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -14,6 +14,7 @@ metadata:
     {{- . | toYaml | nindent 4 }}
   {{- end }}
 spec:
+  ingressClassName: {{ $ing.ingressClassName }}
 {{- if $ing.tls }}
   tls:
     - hosts:

--- a/test/lint/registry.yaml
+++ b/test/lint/registry.yaml
@@ -42,3 +42,24 @@ tests:
             values don't meet the specifications of the schema(s) in the following chart(s):
             apicurio-registry:
             - registry.extraVolumeMounts: Invalid type. Expected: array, given: string
+  - it: ingress is not object
+    set:
+      registry:
+        ingress: "qwe"
+    asserts:
+      - failedTemplate:
+          errorMessage: |
+            values don't meet the specifications of the schema(s) in the following chart(s):
+            apicurio-registry:
+            - registry.ingress: Invalid type. Expected: object, given: string
+  - it: ingressClassName is not string
+    set:
+      registry:
+        ingress:
+          ingressClassName: 1
+    asserts:
+      - failedTemplate:
+          errorMessage: |
+            values don't meet the specifications of the schema(s) in the following chart(s):
+            apicurio-registry:
+            - registry.ingress.ingressClassName: Invalid type. Expected: string, given: integer

--- a/test/unit/ingress.yaml
+++ b/test/unit/ingress.yaml
@@ -1,0 +1,38 @@
+suite: test ingress
+templates:
+  - ingress.yaml
+tests:
+  - it: registry and ingress enabled
+    set:
+      registry.enabled: true
+      registry.ingress.enabled: true
+    asserts:
+      - isKind:
+          of: Ingress
+  - it: ingress
+    set:
+      registry.enabled: true
+      registry:
+        ingress:
+          enabled: true
+          ingressClassName: nginx
+          host: "apicurio.local"
+          path: "/"
+    asserts:
+      - exists:
+          path: spec.ingressClassName
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+      - exists:
+          path: spec.rules[0].host
+      - equal:
+          path: spec.rules[0].host
+          value: apicurio.local
+      - exists:
+          path: spec.rules[0].http.paths[0].path
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /
+    
+

--- a/values.schema.json
+++ b/values.schema.json
@@ -60,6 +60,7 @@
       "required": ["enabled", "host", "path"],
       "properties": {
         "enabled": {"type": "boolean", "default": false, "title": "enable ingress resource"},
+        "ingressClassName": {"type": "string", "default": "", "title": "set ingress controller used for this ingress rule"},
         "host": {"type": "string", "default": "apicurio.local", "title": "hostname"},
         "path": {"type": "string", "default": "/", "title": "ingress path"},
         "tls": {"type": "boolean", "default": false, "title": "enable TLS for ingress host",

--- a/values.yaml
+++ b/values.yaml
@@ -43,6 +43,7 @@ registry:
 
   ingress:
     enabled: false
+    ingressClassName: ""
     host: "apicurio.local"
     path: "/"
     tls: false


### PR DESCRIPTION
Kubernetes Ingress need ingressClassName. So we must set this parameter in helm chart.